### PR TITLE
implement Continuous Euler shim for Refl1D

### DIFF
--- a/molgroups/mol.py
+++ b/molgroups/mol.py
@@ -13,82 +13,15 @@ from refl1d.sample.polymer import mushroom_math, smear
 
 from periodictable.fasta import Molecule, AMINO_ACID_CODES as aa
 from periodictable.core import default_table
-from periodictable.fasta import xray_sld
 from periodictable.fasta import D2O_SLD, H2O_SLD
 
 from molgroups import components as cmp
 
+# for back compatibility
+from molgroups.pdbtools import pdbto8col
+
 D2O_SLD *= 1e-6
 H2O_SLD *= 1e-6
-
-
-def pdbto8col(pdbfilename, datfilename, selection='all', center_of_mass=numpy.array([0, 0, 0]),
-              deuterated_residues=None, xray_wavelength=1.5418):
-    """
-    Creates an 8-column data file for use with ContinuousEuler from a pdb file\
-    with optional selection. "center_of_mass" is the position in space at which to position the
-    molecule's center of mass. "deuterated_residues" is a list of residue IDs for which to use deuterated values
-    """
-    import MDAnalysis
-    from MDAnalysis.lib.util import convert_aa_code
-
-    if deuterated_residues is None:
-        deuterated_residues = []
-
-    elements = default_table()
-
-    molec = MDAnalysis.Universe(pdbfilename)
-    sel = molec.select_atoms(selection)
-    Nres = sel.n_residues
-
-    if not Nres:
-        print('Warning: no atoms selected')
-
-    sel.translate(-sel.center_of_mass() + center_of_mass)
-
-    resnums = []
-    rescoords = []
-    resscatter = []
-    resvol = numpy.zeros(Nres)
-    resesl = numpy.zeros(Nres)
-    resnslH = numpy.zeros(Nres)
-    resnslD = numpy.zeros(Nres)
-    deut_header = ''
-
-    for i in range(Nres):
-        resnum = sel.residues[i].resid
-        resnums.append(resnum)
-        rescoords.append(sel.residues[i].atoms.center_of_mass())
-        key = convert_aa_code(sel.residues[i].resname)
-        if resnum in deuterated_residues:
-            resmol = Molecule(name='Dres', formula=aa[key].formula.replace(elements.H, elements.D),
-                              cell_volume=aa[key].cell_volume)
-        else:
-            resmol = aa[key]
-        resvol[i] = resmol.cell_volume
-        # TODO: Make new column for xray imaginary part (this is real part only)
-        resesl[i] = resmol.cell_volume * xray_sld(resmol.formula, wavelength=xray_wavelength)[0] * 1e-6
-        resnslH[i] = resmol.cell_volume * resmol.sld * 1e-6
-        resnslD[i] = resmol.cell_volume * resmol.Dsld * 1e-6
-
-    resnums = numpy.array(resnums)
-    rescoords = numpy.array(rescoords)
-
-    average_sldH = numpy.sum(resnslH[:, ]) / numpy.sum(resvol[:, ])
-    average_sldD = numpy.sum(resnslD[:, ]) / numpy.sum(resvol[:, ])
-    average_header = f'Average nSLD in H2O: {average_sldH}\nAverage nSLD in D2O: {average_sldD}\n'
-
-    # replace base value in nsl calculation with proper deuterated scattering length
-    # resnsl = resscatter[:, 2]
-    if deuterated_residues is not None:
-        deut_header = 'deuterated residues: ' + ', '.join(map(str, deuterated_residues)) + '\n'
-
-    numpy.savetxt(datfilename, numpy.hstack((resnums[:, None], rescoords, resvol[:, None], resesl[:, None],
-                                             resnslH[:, None], resnslD[:, None])), delimiter='\t',
-                  header=pdbfilename + '\n' + deut_header + average_header + 'resid\tx\ty\tz\tvol\tesl\tnslH\tnslD')
-
-    return datfilename  # allows this to be fed into ContinuousEuler directly
-
 
 class nSLDObj:
     def __init__(self, name=None):
@@ -2234,7 +2167,7 @@ class ContinuousEuler(nSLDObj):
     Uses scipy.spatial library to do Euler rotations in real time
     """
     def __init__(self, fn8col, rotcenter=None, xray=False, **kwargs):
-        """ requires file name fn8col containing 8-column data, any header information commented with #:
+        """ fn8col: file name for 8-column data OR 2-dimensional array of values with shape (n_residues x 8):
             1. residue number
             2. x coordinate
             3. y coordinate
@@ -2244,7 +2177,7 @@ class ContinuousEuler(nSLDObj):
             7. neutron scattering length (H)
             8. neutron scattering length (D)
 
-            Use helper function pdbto8col to create this data file
+            Use helper function pdbtools.pdb_to_residue_data to create this array
 
             The simplest approach is to provide coordinates relative to the center of mass; then,
             "z" corresponds to the absolute z position of the center of mass of the object. Otherwise,
@@ -2252,8 +2185,11 @@ class ContinuousEuler(nSLDObj):
             by "rotcenter" and "z" is the absolute z position of the rotation center.
         """
         super().__init__(**kwargs)
-        self.fn = fn8col
-        resdata = numpy.loadtxt(fn8col)
+        # for back compatibility
+        if isinstance(fn8col, str):
+            resdata = numpy.loadtxt(fn8col)
+        else:
+            resdata = numpy.array(fn8col)
         self.resnums = resdata[:, 0]
         self.rescoords = resdata[:, 1:4]
         if rotcenter is not None:

--- a/molgroups/pdbtools.py
+++ b/molgroups/pdbtools.py
@@ -1,0 +1,99 @@
+import numpy
+
+from periodictable.fasta import Molecule, AMINO_ACID_CODES as aa
+from periodictable.core import default_table
+from periodictable.fasta import xray_sld
+
+def pdb_to_residue_data(pdbfilename, selection='all', center_of_mass=numpy.array([0, 0, 0]),
+              deuterated_residues=None, xray_wavelength=1.5418):
+    """
+    Processes a PDB file into an 8-column residue data array for use with ContinuousEuler from a pdb file\
+    with optional selection. "center_of_mass" is the position in space at which to position the
+    molecule's center of mass. "deuterated_residues" is a list of residue IDs for which to use deuterated values
+
+    Returns (n_residues x 8) array with columns:
+    1. residue number
+    2. x coordinate
+    3. y coordinate
+    4. z coordinate
+    5. residue volume
+    6. electon scattering length
+    7. neutron scattering length (H)
+    8. neutron scattering length (D)
+    
+    """
+    import MDAnalysis
+    from MDAnalysis.lib.util import convert_aa_code
+
+    if deuterated_residues is None:
+        deuterated_residues = []
+
+    elements = default_table()
+
+    molec = MDAnalysis.Universe(pdbfilename)
+    sel = molec.select_atoms(selection)
+    Nres = sel.n_residues
+
+    if not Nres:
+        print('Warning: no atoms selected')
+
+    sel.translate(-sel.center_of_mass() + center_of_mass)
+
+    resnums = []
+    rescoords = []
+    resscatter = []
+    resvol = numpy.zeros(Nres)
+    resesl = numpy.zeros(Nres)
+    resnslH = numpy.zeros(Nres)
+    resnslD = numpy.zeros(Nres)
+    deut_header = ''
+
+    for i in range(Nres):
+        resnum = sel.residues[i].resid
+        resnums.append(resnum)
+        rescoords.append(sel.residues[i].atoms.center_of_mass())
+        key = convert_aa_code(sel.residues[i].resname)
+        if resnum in deuterated_residues:
+            resmol = Molecule(name='Dres', formula=aa[key].formula.replace(elements.H, elements.D),
+                              cell_volume=aa[key].cell_volume)
+        else:
+            resmol = aa[key]
+        resvol[i] = resmol.cell_volume
+        # TODO: Make new column for xray imaginary part (this is real part only)
+        resesl[i] = resmol.cell_volume * xray_sld(resmol.formula, wavelength=xray_wavelength)[0] * 1e-6
+        resnslH[i] = resmol.cell_volume * resmol.sld * 1e-6
+        resnslD[i] = resmol.cell_volume * resmol.Dsld * 1e-6
+
+    resnums = numpy.array(resnums)
+    rescoords = numpy.array(rescoords)
+
+    # replace base value in nsl calculation with proper deuterated scattering length
+    # resnsl = resscatter[:, 2]
+
+    return numpy.hstack((resnums[:, None], rescoords, resvol[:, None], resesl[:, None],
+                                             resnslH[:, None], resnslD[:, None]))
+
+
+def pdbto8col(pdbfilename, datfilename, selection='all', center_of_mass=numpy.array([0, 0, 0]),
+            deuterated_residues=None, xray_wavelength=1.5418):
+    """Saves 8-column residue data to a file (for back compatibility)"""
+
+    processed_data = pdb_to_residue_data(pdbfilename, selection, center_of_mass,
+                        deuterated_residues, xray_wavelength)
+    
+    deut_header = ''
+    if deuterated_residues is not None:
+        deut_header = 'deuterated residues: ' + ', '.join(map(str, deuterated_residues)) + '\n'
+
+    resvol = processed_data[:, 4]
+    resnslH = processed_data[:, 6]
+    resnslD = processed_data[:, 7]
+
+    average_sldH = numpy.sum(resnslH[:, ]) / numpy.sum(resvol[:, ])
+    average_sldD = numpy.sum(resnslD[:, ]) / numpy.sum(resvol[:, ])
+    average_header = f'Average nSLD in H2O: {average_sldH}\nAverage nSLD in D2O: {average_sldD}\n'
+
+    numpy.savetxt(datfilename, processed_data, delimiter='\t',
+                header=pdbfilename + '\n' + deut_header + average_header + 'resid\tx\ty\tz\tvol\tesl\tnslH\tnslD')
+
+    return datfilename

--- a/molgroups/refl1d_interface/__init__.py
+++ b/molgroups/refl1d_interface/__init__.py
@@ -17,4 +17,5 @@ from molgroups.refl1d_interface.groups import (Substrate,
                                                PolymerBrush,
                                                PolymerMushroom,
                                                Monolayer,
+                                               ContinuousEuler
                                                )

--- a/molgroups/refl1d_interface/groups.py
+++ b/molgroups/refl1d_interface/groups.py
@@ -722,10 +722,41 @@ class Freeform(MolgroupsInterface):
                                      sigma=self.sigma.value)
         
 # ============= Euler objects =================
+@dataclass
+class ContinuousEuler(MolgroupsInterface):
+    
+    _molgroup: mol.ContinuousEuler | None = None
 
-class ContinuousEulerInterface(MolgroupsInterface):
-    pass
+    fn8col: str = ''
+    rotcenter: list = None
+    gamma: Parameter = field(default_factory=lambda: Parameter(name='gamma rotation', value=0))
+    beta: Parameter = field(default_factory=lambda: Parameter(name='beta rotation', value=0))
+    z: Parameter = field(default_factory=lambda: Parameter(name='z position', value=0))
+    sigma: Parameter = field(default_factory=lambda: Parameter(name='roughness', value=5))
 
+    center_of_volume: ReferencePoint = field(default_factory=lambda: ReferencePoint(name='center of volume', description='center of volume'))
+
+    def __post_init__(self):
+        self._molgroup = mol.ContinuousEuler(name=self.name, fn8col=self.fn8col, rotcenter=self.rotcenter, xray=False)
+
+         # protects against initial errors calculation self.rho
+        self._molgroup.fnSetBulknSLD(0.0)
+
+        self._group_names = {f'{self.name}': [f'{self.name}']}
+
+        self.center_of_volume.set_function(self._center_of_volume)
+
+        super().__post_init__()
+
+    def update(self) -> None:
+
+        self._molgroup.fnSet(gamma=self.gamma.value,
+                             beta=self.beta.value,
+                             zpos=self.z.value,
+                             sigma=self.sigma.value,
+                             nf=self.nf.value,
+                             bulknsld=self.bulknsld.value * 1e-6)
+        
 # ============= Complex objects ===============
 
 @dataclass

--- a/molgroups/refl1d_interface/groups.py
+++ b/molgroups/refl1d_interface/groups.py
@@ -727,8 +727,8 @@ class ContinuousEuler(MolgroupsInterface):
     
     _molgroup: mol.ContinuousEuler | None = None
 
-    fn8col: str = ''
-    rotcenter: list = None
+    residue_data: list | np.ndarray = None
+    rotcenter: list | np.ndarray = None
     gamma: Parameter = field(default_factory=lambda: Parameter(name='gamma rotation', value=0))
     beta: Parameter = field(default_factory=lambda: Parameter(name='beta rotation', value=0))
     z: Parameter = field(default_factory=lambda: Parameter(name='z position', value=0))
@@ -738,7 +738,7 @@ class ContinuousEuler(MolgroupsInterface):
     center_of_volume: ReferencePoint = field(default_factory=lambda: ReferencePoint(name='center of volume', description='center of volume'))
 
     def __post_init__(self):
-        self._molgroup = mol.ContinuousEuler(name=self.name, fn8col=self.fn8col, rotcenter=self.rotcenter, xray=False)
+        self._molgroup = mol.ContinuousEuler(name=self.name, fn8col=self.residue_data, rotcenter=self.rotcenter, xray=False)
 
          # protects against initial errors calculation self.rho
         self._molgroup.fnSetBulknSLD(0.0)

--- a/molgroups/refl1d_interface/groups.py
+++ b/molgroups/refl1d_interface/groups.py
@@ -733,6 +733,7 @@ class ContinuousEuler(MolgroupsInterface):
     beta: Parameter = field(default_factory=lambda: Parameter(name='beta rotation', value=0))
     z: Parameter = field(default_factory=lambda: Parameter(name='z position', value=0))
     sigma: Parameter = field(default_factory=lambda: Parameter(name='roughness', value=5))
+    proton_exchange_efficiency: Parameter = field(default_factory=lambda: Parameter(name='proton exchange efficiency', value=1.0))
 
     center_of_volume: ReferencePoint = field(default_factory=lambda: ReferencePoint(name='center of volume', description='center of volume'))
 
@@ -750,6 +751,7 @@ class ContinuousEuler(MolgroupsInterface):
 
     def update(self) -> None:
 
+        self._molgroup.protexchratio = self.proton_exchange_efficiency.value
         self._molgroup.fnSet(gamma=self.gamma.value,
                              beta=self.beta.value,
                              zpos=self.z.value,


### PR DESCRIPTION
Implements the `ContinuousEuler` shim for `refl1d`.

To support serialization, the shim takes a `residue_data` array instead of a string path to a processed data file, as the underlying `mol.ContinuousEuler` object does.

`mol.ContinuousEuler` was also updated to allow either a string input (which is interpreted as a path) or an array of residue coordinates and scattering length densities.