### PR TITLE
Add module for combining SasView models with reflectivity data

### DIFF
--- a/molgroups/refl1d_interface/__init__.py
+++ b/molgroups/refl1d_interface/__init__.py
@@ -3,7 +3,8 @@ from molgroups.refl1d_interface.experiment import (MolgroupsExperiment,
                                                    make_samples)
 
 from molgroups.refl1d_interface.sas import (SASReflectivityModel,
-                                          SASReflectivityExperiment)
+                                          SASReflectivityExperiment,
+                                          SASReflectivityMolgroupsExperiment)
 
 from molgroups.refl1d_interface.layers import (MolgroupsStack,
                                                MolgroupsLayer)

--- a/molgroups/refl1d_interface/__init__.py
+++ b/molgroups/refl1d_interface/__init__.py
@@ -3,8 +3,10 @@ from molgroups.refl1d_interface.experiment import (MolgroupsExperiment,
                                                    make_samples)
 
 from molgroups.refl1d_interface.sas import (StandardSASModel,
-                                          SASReflectivityExperiment,
-                                          SASReflectivityMolgroupsExperiment)
+                                            MolgroupsSphereSASModel,
+                                            SASModel,
+                                            SASReflectivityExperiment,
+                                            SASReflectivityMolgroupsExperiment)
 
 from molgroups.refl1d_interface.layers import (MolgroupsStack,
                                                MolgroupsLayer)

--- a/molgroups/refl1d_interface/__init__.py
+++ b/molgroups/refl1d_interface/__init__.py
@@ -2,7 +2,7 @@ from molgroups.refl1d_interface.experiment import (MolgroupsExperiment,
                                                    MolgroupsMixedExperiment,
                                                    make_samples)
 
-from molgroups.refl1d_interface.sas import (SASReflectivityModel,
+from molgroups.refl1d_interface.sas import (StandardSASModel,
                                           SASReflectivityExperiment,
                                           SASReflectivityMolgroupsExperiment)
 

--- a/molgroups/refl1d_interface/__init__.py
+++ b/molgroups/refl1d_interface/__init__.py
@@ -2,6 +2,9 @@ from molgroups.refl1d_interface.experiment import (MolgroupsExperiment,
                                                    MolgroupsMixedExperiment,
                                                    make_samples)
 
+from molgroups.refl1d_interface.sas import (SASReflectivityModel,
+                                          SASReflectivityExperiment)
+
 from molgroups.refl1d_interface.layers import (MolgroupsStack,
                                                MolgroupsLayer)
 

--- a/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas.py
+++ b/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas.py
@@ -1,0 +1,178 @@
+"""Example script using molgroups Refl1D interface objects"""
+
+import numpy as np
+from refl1d.names import Parameter, SLD, Slab, FitProblem, load4
+from molgroups import components as cmp
+from molgroups.refl1d_interface import (SolidSupportedBilayer,
+                                        MolgroupsLayer,
+                                        MolgroupsStack,
+                                        MolgroupsExperiment)
+
+from molgroups.refl1d_interface import SASReflectivityMolgroupsExperiment, SASReflectivityModel
+
+## === Probes/data files ===
+probe_d2o = load4('ch061_d2o_ph7.refl', back_reflectivity=True, name='D2O')
+probe_h2o = load4('ch060_h2o_ph7.refl', back_reflectivity=True, name='H2O')
+
+# Probe parameters
+probes = [probe_d2o, probe_h2o]
+
+# Probe parameters
+intensity = Parameter(name='intensity', value=0.8).range(0.65, 1.0)
+sample_broadening = Parameter(name='sample broadening', value=0.0).range(-0.003, 0.02)
+theta_offset = Parameter(name='theta offset', value=0.0).range(-0.02, 0.02)
+
+# apply background and intensity to all probes
+for probe in probes:
+    probe.background.limits = (-np.inf, np.inf)
+    probe.background.range(-1e-6, 1e-5)
+    probe.intensity = intensity
+
+    # if probes support these
+    probe.sample_broadening = sample_broadening
+    probe.theta_offset = theta_offset
+
+## === Structural parameters ===
+
+vf_bilayer = Parameter(name='volume fraction bilayer', value=0.9).range(0.0, 1.0)
+l_lipid1 = Parameter(name='inner acyl chain thickness', value=10.0).range(8, 30)
+l_lipid2 = Parameter(name='outer acyl chain thickness', value=10.0).range(8, 18)
+l_submembrane = Parameter(name='submembrane thickness', value=10.0).range(0, 50)
+sigma = Parameter(name='bilayer roughness', value=5).range(0.5, 9)
+global_rough = Parameter(name ='substrate roughness', value=5).range(2, 9)
+tiox_rough = Parameter(name='titanium oxide roughness', value=4).range(2, 9)
+d_oxide = Parameter(name='silicon oxide layer thickness', value=10).range(5, 30)
+d_tiox =  Parameter(name='titanium oxide layer thickness', value=110).range(100, 200)
+
+## === Materials ===
+
+# Material definitions
+d2o = SLD(name='d2o', rho=6.3000, irho=0.0000)
+h2o = SLD(name='h2o', rho=-0.56, irho=0.0000)
+tiox = SLD(name='tiox', rho=2.1630, irho=0.0000)
+siox = SLD(name='siox', rho=4.1000, irho=0.0000)
+silicon = SLD(name='silicon', rho=2.0690, irho=0.0000)
+
+# Material SLD parameters
+d2o.rho.range(5.3000, 6.36)
+h2o.rho.range(-0.56, 0.6)
+tiox.rho.range(1.2, 3.2)
+siox.rho.range(2.8, 4.8)
+
+## === Molecular groups ===
+
+# overlap between substrate and molgroups layer
+overlap = 30.0
+
+# thickness of molgroups layer
+thickness = 200.0
+
+# define lipids and number fractions
+DOPC = cmp.Lipid(name='DOPC', headgroup=cmp.pc, tails=2 * [cmp.oleoyl], methyls=[cmp.methyl])
+lipidlist = [DOPC]
+lipid_nf = [1.0]
+
+def bilayer(substrate, contrast):
+
+    blm = SolidSupportedBilayer(name='bilayer',
+                        overlap=overlap,
+                        lipids=lipidlist,
+                        inner_lipid_nf=lipid_nf,
+                        outer_lipid_nf=lipid_nf,
+                        rho_substrate=tiox.rho,
+                        l_siox=0.0,
+                        vf_bilayer=vf_bilayer,
+                        l_lipid1=l_lipid1,
+                        l_lipid2=l_lipid2,
+                        l_submembrane=l_submembrane,
+                        substrate_rough=tiox_rough,
+                        sigma=sigma)
+    
+    mollayer = MolgroupsLayer(base_group=blm,
+                            thickness=thickness,
+                            contrast=contrast,
+                            name='bilayer layer ' + contrast.name)
+    
+    return MolgroupsStack(substrate=substrate,
+                        molgroups_layer=mollayer,
+                        name=mollayer.name)
+
+## == Sample layer stack ==
+
+layer_silicon = Slab(material=silicon, thickness=0.0000, interface=global_rough)
+layer_siox = Slab(material=siox, thickness=d_oxide, interface=global_rough)
+layer_tiox = Slab(material=tiox, thickness=d_tiox - overlap, interface=0.00)
+
+substrate = layer_silicon | layer_siox | layer_tiox
+
+# Use the bilayer definition function to generate the bilayer SLD profile, passing in the relevant parameters.
+sample_d2o, sample_h2o = [bilayer(substrate, contrast) for contrast in [d2o, h2o]]
+
+## === Problem definition ===
+## step = True corresponds to a calculation of the reflectivity from an actual profile
+## with microslabbed interfaces.  When step = False, the Nevot-Croce
+## approximation is used to account for roughness.  This approximation speeds up
+## the calculation tremendously, and is reasonably accurate as long as the
+## roughness is much less than the layer thickness
+step = False
+STEPSIZE=0.5
+
+
+def _angular_resolution(L12: float = 1215.0, S1: float = 25, S2: float = 25) -> np.ndarray:
+    """
+    Calculate FWHM angular resolution (degrees)
+    L12 : float
+        Distance from source to detector in mm
+    S1 : float
+        Source aperture size in mm
+    S2 : float
+        Sample aperture size in mm
+    """
+    import numpy as np
+
+    return np.arctan((S1 + S2 ) / L12) * (180.0 / np.pi)
+
+from refl1d.probe.resolution import dTdL2dQ
+
+def dLexp(L):
+    Lpar = 0.0756
+    A=0.1309
+    K=0.3492
+
+    return Lpar - A * np.exp(-K * L)
+
+dTl = np.ones_like(probe_d2o.Q) * _angular_resolution()
+
+bilayer_thickness = Parameter(name='SANS bilayer thickness', value=40.0).range(20.0, 80.0)
+bilayer_spacing = Parameter(name='SANS bilayer spacing', value=20.0).range(5.0, 50.0)
+volume_fraction_bilayer = Parameter(name='SANS volume fraction', value=0.00001).range(0.0, 0.0001)
+n_bilayers =  Parameter(name='SANS number of bilayers', value=4).range(1, 20)
+
+sans_parameters = {'scale': 1.0,
+                    'background': 0.0,
+                    'sld': 0.4,
+                    'thick_shell': bilayer_thickness,
+                    'thick_solvent': bilayer_spacing,
+                    'radius': 100.0,
+                    'volfraction': volume_fraction_bilayer,
+                    'n_shells': n_bilayers * 2 - 1
+                    }
+
+sasmodel_d = SASReflectivityModel(sas_model_name='multilayer_vesicle',
+                                dtheta_l=dTl,
+                                parameters=sans_parameters | {'sld_solvent': d2o.rho})
+
+sasmodel_h = SASReflectivityModel(sas_model_name='multilayer_vesicle',
+                                dtheta_l=dTl,
+                                parameters=sans_parameters | {'sld_solvent': h2o.rho})
+
+
+model_d2o = SASReflectivityMolgroupsExperiment(sas_model=sasmodel_d, sample=sample_d2o, probe=probe_d2o, dz=STEPSIZE, step_interfaces = step)
+model_h2o = SASReflectivityMolgroupsExperiment(sas_model=sasmodel_h, sample=sample_h2o, probe=probe_h2o, dz=STEPSIZE, step_interfaces = step)
+
+#model_d2o = MolgroupsExperiment(sample=sample_d2o, probe=probe_d2o, dz=STEPSIZE, step_interfaces = step)
+#model_h2o = MolgroupsExperiment(sample=sample_h2o, probe=probe_h2o, dz=STEPSIZE, step_interfaces = step)
+
+problem = FitProblem([model_d2o, model_h2o])
+
+problem.name = "tiox_dopc_d2o_h2o"

--- a/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas.py
+++ b/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas.py
@@ -9,7 +9,7 @@ from molgroups.refl1d_interface import (SolidSupportedBilayer,
                                         MolgroupsStack,
                                         MolgroupsExperiment)
 
-from molgroups.refl1d_interface import SASReflectivityMolgroupsExperiment, SASReflectivityModel
+from molgroups.refl1d_interface import SASReflectivityMolgroupsExperiment, StandardSASModel
 
 ## === Probes/data files ===
 probe_d2o = load4('ch061_d2o_ph7.refl', back_reflectivity=True, name='D2O')
@@ -141,13 +141,13 @@ sans_parameters = {'scale': 1.0,
                     'n_shells': n_bilayers * 2 - 1
                     }
 
-sasmodel_d = SASReflectivityModel(sas_model_name='multilayer_vesicle',
+sasmodel_d = StandardSASModel(sas_model_name='multilayer_vesicle',
                                 dtheta_l=dTl,
-                                parameters=sans_parameters | {'sld_solvent': d2o.rho})
+                                params=sans_parameters | {'sld_solvent': d2o.rho})
 
-sasmodel_h = SASReflectivityModel(sas_model_name='multilayer_vesicle',
+sasmodel_h = StandardSASModel(sas_model_name='multilayer_vesicle',
                                 dtheta_l=dTl,
-                                parameters=sans_parameters | {'sld_solvent': h2o.rho})
+                                params=sans_parameters | {'sld_solvent': h2o.rho})
 
 
 model_d2o = SASReflectivityMolgroupsExperiment(sas_model=sasmodel_d, sample=sample_d2o, probe=probe_d2o, dz=STEPSIZE, step_interfaces = step)

--- a/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas_molgroups.py
+++ b/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas_molgroups.py
@@ -153,8 +153,8 @@ L2 = 330.0
 L1 = 1403.0 + 330.0
 dTl = 2 * np.ones_like(probe_d2o.Q) * divergence(0, (S1_transverse, S2_transverse), (L1, L2))
 
-sansmodel_d = MolgroupsSphereSASModel(sans_bilayer(d2o), r_core=100.0, scale=scale_sans, dz=SANS_STEPSIZE)
-sansmodel_h = MolgroupsSphereSASModel(sans_bilayer(h2o), r_core=100.0, scale=scale_sans, dz=SANS_STEPSIZE)
+sansmodel_d = MolgroupsSphereSASModel(sans_bilayer(d2o), r_core=100.0, scale=scale_sans, dz=SANS_STEPSIZE, dtheta_l=dTl, geometry_exponent=0)
+sansmodel_h = MolgroupsSphereSASModel(sans_bilayer(h2o), r_core=100.0, scale=scale_sans, dz=SANS_STEPSIZE, dtheta_l=dTl, geometry_exponent=0)
 
 model_d2o = SASReflectivityMolgroupsExperiment(sas_model=sansmodel_d, sample=sample_d2o, probe=probe_d2o, dz=STEPSIZE, step_interfaces = step)
 model_h2o = SASReflectivityMolgroupsExperiment(sas_model=sansmodel_h, sample=sample_h2o, probe=probe_h2o, dz=STEPSIZE, step_interfaces = step)

--- a/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas_molgroups.py
+++ b/molgroups/refl1d_interface/examples/tiox_dopc/tiox_dopc_sas_molgroups.py
@@ -1,0 +1,164 @@
+"""Example script using molgroups Refl1D interface objects"""
+
+import numpy as np
+from refl1d.names import Parameter, SLD, Slab, FitProblem, load4
+from refl1d.probe.resolution import divergence
+from molgroups import components as cmp
+from molgroups.refl1d_interface import (SolidSupportedBilayer,
+                                        MolgroupsLayer,
+                                        MolgroupsStack,
+                                        MolgroupsExperiment)
+
+from molgroups.refl1d_interface import SASReflectivityMolgroupsExperiment, MolgroupsSphereSASModel
+
+## === Probes/data files ===
+probe_d2o = load4('ch061_d2o_ph7.refl', back_reflectivity=True, name='D2O')
+probe_h2o = load4('ch060_h2o_ph7.refl', back_reflectivity=True, name='H2O')
+
+# Probe parameters
+probes = [probe_d2o, probe_h2o]
+
+# Probe parameters
+intensity = Parameter(name='intensity', value=0.8).range(0.65, 1.0)
+sample_broadening = Parameter(name='sample broadening', value=0.0).range(-0.003, 0.02)
+theta_offset = Parameter(name='theta offset', value=0.0).range(-0.02, 0.02)
+
+# apply background and intensity to all probes
+for probe in probes:
+    probe.background.limits = (-np.inf, np.inf)
+    probe.background.range(-1e-6, 1e-5)
+    probe.intensity = intensity
+
+    # if probes support these
+    probe.sample_broadening = sample_broadening
+    probe.theta_offset = theta_offset
+
+## === Structural parameters ===
+
+vf_bilayer = Parameter(name='volume fraction bilayer', value=0.9).range(0.0, 1.0)
+l_lipid1 = Parameter(name='inner acyl chain thickness', value=10.0).range(8, 30)
+l_lipid2 = Parameter(name='outer acyl chain thickness', value=10.0).range(8, 18)
+l_submembrane = Parameter(name='submembrane thickness', value=10.0).range(0, 50)
+sigma = Parameter(name='bilayer roughness', value=5).range(0.5, 9)
+global_rough = Parameter(name ='substrate roughness', value=5).range(2, 9)
+tiox_rough = Parameter(name='titanium oxide roughness', value=4).range(2, 9)
+d_oxide = Parameter(name='silicon oxide layer thickness', value=10).range(5, 30)
+d_tiox =  Parameter(name='titanium oxide layer thickness', value=110).range(100, 200)
+
+scale_sans = Parameter(name='SANS scale', value=1e-5).range(0, 1e-4)
+l_lipid_sans = Parameter(name='SANS lipid thickness', value=10.0).range(5, 30)
+sigma_sans = Parameter(name='SANS bilayer roughness', value=5).range(0.5, 9)
+bilayer_separation = Parameter(name='SANS bilayer separation', value=20.0).range(0, 200)
+n_bilayers = Parameter(name='SANS number of bilayers', value=1).range(1, 20)
+
+## === Materials ===
+
+# Material definitions
+d2o = SLD(name='d2o', rho=6.3000, irho=0.0000)
+h2o = SLD(name='h2o', rho=-0.56, irho=0.0000)
+tiox = SLD(name='tiox', rho=2.1630, irho=0.0000)
+siox = SLD(name='siox', rho=4.1000, irho=0.0000)
+silicon = SLD(name='silicon', rho=2.0690, irho=0.0000)
+
+# Material SLD parameters
+d2o.rho.range(5.3000, 6.36)
+h2o.rho.range(-0.56, 0.6)
+tiox.rho.range(1.2, 3.2)
+siox.rho.range(2.8, 4.8)
+
+## === Molecular groups ===
+
+# overlap between substrate and molgroups layer
+overlap = 30.0
+
+# thickness of molgroups layer
+thickness = 200.0
+
+# define lipids and number fractions
+DOPC = cmp.Lipid(name='DOPC', headgroup=cmp.pc, tails=2 * [cmp.oleoyl], methyls=[cmp.methyl])
+lipidlist = [DOPC]
+lipid_nf = [1.0]
+
+def bilayer(substrate, contrast):
+
+    blm = SolidSupportedBilayer(name='bilayer',
+                        overlap=overlap,
+                        lipids=lipidlist,
+                        inner_lipid_nf=lipid_nf,
+                        outer_lipid_nf=lipid_nf,
+                        rho_substrate=tiox.rho,
+                        l_siox=0.0,
+                        vf_bilayer=vf_bilayer,
+                        l_lipid1=l_lipid1,
+                        l_lipid2=l_lipid2,
+                        l_submembrane=l_submembrane,
+                        substrate_rough=tiox_rough,
+                        sigma=sigma)
+    
+    mollayer = MolgroupsLayer(base_group=blm,
+                            thickness=thickness,
+                            contrast=contrast,
+                            name='bilayer layer ' + contrast.name)
+    
+    return MolgroupsStack(substrate=substrate,
+                        molgroups_layer=mollayer,
+                        name=mollayer.name)
+
+def sans_bilayer(contrast):
+
+    blm = SolidSupportedBilayer(name='bilayer',
+                        overlap=20,
+                        lipids=lipidlist,
+                        inner_lipid_nf=lipid_nf,
+                        outer_lipid_nf=lipid_nf,
+                        rho_substrate=contrast.rho,
+                        l_siox=0.0,
+                        vf_bilayer=1.0,
+                        l_lipid1=l_lipid_sans,
+                        l_lipid2=l_lipid_sans,
+                        l_submembrane=0,
+                        substrate_rough=0.0,
+                        sigma=sigma_sans)
+    
+    return MolgroupsLayer(base_group=blm,
+                            thickness=100.0,
+                            contrast=contrast,
+                            name='SANS bilayer layer ' + contrast.name)
+
+## == Sample layer stack ==
+
+layer_silicon = Slab(material=silicon, thickness=0.0000, interface=global_rough)
+layer_siox = Slab(material=siox, thickness=d_oxide, interface=global_rough)
+layer_tiox = Slab(material=tiox, thickness=d_tiox - overlap, interface=0.00)
+
+substrate = layer_silicon | layer_siox | layer_tiox
+
+# Use the bilayer definition function to generate the bilayer SLD profile, passing in the relevant parameters.
+sample_d2o, sample_h2o = [bilayer(substrate, contrast) for contrast in [d2o, h2o]]
+
+## === Problem definition ===
+## step = True corresponds to a calculation of the reflectivity from an actual profile
+## with microslabbed interfaces.  When step = False, the Nevot-Croce
+## approximation is used to account for roughness.  This approximation speeds up
+## the calculation tremendously, and is reasonably accurate as long as the
+## roughness is much less than the layer thickness
+step = False
+STEPSIZE=1.0
+SANS_STEPSIZE=2.0
+
+# calculate full transverse divergence (2 * FWHM) for MAGIK reflectometer
+S1_transverse = 150.0
+S2_transverse = 25.0
+L2 = 330.0
+L1 = 1403.0 + 330.0
+dTl = 2 * np.ones_like(probe_d2o.Q) * divergence(0, (S1_transverse, S2_transverse), (L1, L2))
+
+sansmodel_d = MolgroupsSphereSASModel(sans_bilayer(d2o), r_core=100.0, scale=scale_sans, dz=SANS_STEPSIZE)
+sansmodel_h = MolgroupsSphereSASModel(sans_bilayer(h2o), r_core=100.0, scale=scale_sans, dz=SANS_STEPSIZE)
+
+model_d2o = SASReflectivityMolgroupsExperiment(sas_model=sansmodel_d, sample=sample_d2o, probe=probe_d2o, dz=STEPSIZE, step_interfaces = step)
+model_h2o = SASReflectivityMolgroupsExperiment(sas_model=sansmodel_h, sample=sample_h2o, probe=probe_h2o, dz=STEPSIZE, step_interfaces = step)
+
+problem = FitProblem([model_d2o, model_h2o])
+
+problem.name = "tiox_dopc_d2o_h2o"

--- a/molgroups/refl1d_interface/experiment.py
+++ b/molgroups/refl1d_interface/experiment.py
@@ -31,6 +31,10 @@ class MolgroupsExperiment(Experiment):
                  version: str | None = None,
                  auto_tag=False):
         super().__init__(sample, probe, name, roughness_limit, dz, dA, step_interfaces, smoothness, interpolation, constraints, version, auto_tag)
+
+        # store molgroups layer
+        self._molgroups_layers = {self.sample.molgroups_layer.name: self.sample.molgroups_layer}
+
         self.register_webview_plot(plot_title=self.sample.name,
                                    plot_function=functools.partial(cvo_plot, self.sample.molgroups_layer),
                                    change_with='parameter')
@@ -56,11 +60,15 @@ class MolgroupsMixedExperiment(MixedExperiment):
                  interpolation=0,
                  **kw):
         super().__init__(samples, ratio, probe, name, coherent, interpolation, **kw)
+
+        self._molgroups_layers = {}
         for i, (p, s) in enumerate(zip(self.parts, self.samples)):
             
             # if MolgroupsStack samples, use MolgroupsExperiments
             if isinstance(s, MolgroupsStack):
                 p = MolgroupsExperiment(s, probe, name=s.name, **kw)
+                self.parts[i] = p
+                self._molgroups_layers.update(p._molgroups_layers)
 
             # experiment inherits registered webview plots
             for key, item in p._webview_plots.items():

--- a/molgroups/refl1d_interface/plots.py
+++ b/molgroups/refl1d_interface/plots.py
@@ -167,14 +167,8 @@ def _calc_profile(problem: FitProblem | None, model_index: int, layer_name: str,
     model: Experiment = list(problem.models)[model_index]
     model.update()
     model.nllf()
-    if hasattr(model, 'parts'):
-        for p in model.parts:
-            if hasattr(p.sample, 'molgroups_layer'):
-                if p.sample.molgroups_layer.name == layer_name:
-                    layer = p.sample.molgroups_layer
-                    break
-    else:
-        layer = model.sample.molgroups_layer
+    layer: MolgroupsLayer = model._molgroups_layers[layer_name]
+    
     imoldat = {}
     for group in [layer.base_group] + layer.add_groups + layer.overlay_groups:
         for k, v in group._group_names.items():

--- a/molgroups/refl1d_interface/sas.py
+++ b/molgroups/refl1d_interface/sas.py
@@ -210,7 +210,7 @@ class StandardSASModel(SASModel):
         plots: PlotDict = {'parameter': [], 'uncertainty': []}
         
         # Register profile plot only if supported by the kernel
-        if self._engines and hasattr(self._engines[0], 'profile'):
+        if self._engines and self._engines[0].model.info.profile is not None:
              plots['parameter'].append(('SANS Profile', sans_profile_plot))
              
         return plots
@@ -364,8 +364,8 @@ class MolgroupsSphereSASModel(SASModel):
         # Initialize kernel with safe limit (10) to check for 'profile' capability
         if self._engines is None and self._probe is not None:
              self._ensure_kernel(10)
-             
-        if self._engines and hasattr(self._engines[0], 'profile'):
+        
+        if self._engines and self._engines[0].model.info.profile is not None:
             # Insert at the beginning of the parameter list
             plots['parameter'].insert(0, ('SANS Radial Profile', sans_profile_plot))
 

--- a/molgroups/refl1d_interface/sas.py
+++ b/molgroups/refl1d_interface/sas.py
@@ -36,12 +36,28 @@ class SASReflectivityMixin:
     need to calculate resolution.
     """
     
-    # Type hinting for the mixin (expects these to exist on the child)
+    # Type hinting for the mixin
     sas_model: 'SASReflectivityModel'
-    _sasmodel: object
+    _sasmodels: list[DirectModel]
     _cache: dict
     probe: object
     name: str
+
+    def __getstate__(self):
+        """
+        Custom pickling state: Exclude '_sasmodels' because DirectModel objects 
+        contain C-pointers (ctypes) which cannot be pickled.
+        """
+        state = self.__dict__.copy()
+        # Remove the unpickleable list of DirectModels
+        state.pop('_sasmodels', None)
+        return state
+
+    def __setstate__(self, state):
+        """
+        Restore state. '_sasmodels' will be missing and rebuilt lazily in sas().
+        """
+        self.__dict__.update(state)
 
     def _init_sas(self, sas_model):
         """ Helper to initialize SAS components. Call this from the child __init__ """
@@ -53,43 +69,25 @@ class SASReflectivityMixin:
                 if not isinstance(p, Parameter):
                     self.sas_model.parameters[k] = Parameter.default(p, name=k)
 
-            # Initialize Kernel
-            if sas_model.sas_model_name is not None:
-                self._sasmodel = load_model(sas_model.sas_model_name)
+            # Build the engines initially
+            self._build_sas_engines()
         
         # Register the Decomposition Plot
-        # Note: 'self' here will be the full Experiment instance
         self.register_webview_plot(
             plot_title='SAS/Refl Decomposition',
             plot_function=sas_decomposition_plot,
             change_with='parameter'
         )
 
-    def parameters(self):
-        # Merge parent parameters (Experiment/Molgroups) with SAS parameters
-        return super().parameters() | {'sas': self.sas_model.parameters if self.sas_model is not None else {}}
-
-    def _calc_Iq(self, probe, dtheta_l):
-        """ Calculate the small angle scattering I(q) """
-        data = Data1D(x=probe.Q)
-        
-        # calculate Q-transformed slit widths. dQ is assumed to be sigma, while dtheta_l is 2 * FWHM
-        data.dxl = dTdL2dQ(np.zeros_like(probe.T), dtheta_l, probe.L, probe.dL)
-        data.dxw = 2 * sigma2FWHM(probe.dQ)
-        
-        pars = {k: float(p) for k, p in self.sas_model.parameters.items()}
-        
-        # Calculate
-        sasmodel = DirectModel(data=data, model=self._sasmodel)
-        Iq = sasmodel(**pars)
-        return Iq
-
-    def sas(self):
-        """ Calculate the small angle scattering I(q) """
-        key = ("small_angle_scattering")
-        if key not in self._cache:
+    def _build_sas_engines(self):
+        """
+        Compiles the sasmodels DirectModel objects. 
+        Separated from _init_sas so it can be recalled after pickling.
+        """
+        if self.sas_model is not None and self.sas_model.sas_model_name is not None:
+            kernel = load_model(self.sas_model.sas_model_name)
             probes = [self.probe] if not isinstance(self.probe, ProbeSet) else self.probe.probes
-            
+
             # Broadcast dtheta_l if it is None or a scalar
             dtheta_val = self.sas_model.dtheta_l
             if np.isscalar(dtheta_val) or dtheta_val is None:
@@ -97,11 +95,45 @@ class SASReflectivityMixin:
             else:
                 dtheta_list = dtheta_val
             
-            # Calculate and Stack
-            Iq_parts = [self._calc_Iq(probe, dt) for probe, dt in zip(probes, dtheta_list)]
-            self._cache[key] = np.hstack(Iq_parts)
+            # Recreate the list of DirectModels
+            self._sasmodels = [self._setup_model(kernel, probe, dtheta_l) for probe, dtheta_l in zip(probes, dtheta_list)]
+        else:
+            self._sasmodels = []
 
-            Iq = np.hstack([self._calc_Iq(probe, dtheta_l) for probe, dtheta_l in zip(probes, dtheta_list)])
+    def parameters(self):
+        # Merge parent parameters with SAS parameters
+        return super().parameters() | {'sas': self.sas_model.parameters if self.sas_model is not None else {}}
+
+    def _setup_model(self, kernel, probe, dtheta_l):
+        """ Set up the probe-specific model for calculation """
+        data = Data1D(x=probe.Q)
+        
+        # calculate Q-transformed slit widths
+        data.dxl = dTdL2dQ(np.zeros_like(probe.T), dtheta_l, probe.L, probe.dL)
+        data.dxw = 2 * sigma2FWHM(probe.dQ)
+
+        return DirectModel(data=data, model=kernel)
+
+    def sas(self):
+        """ Calculate the small angle scattering I(q) """
+        key = ("small_angle_scattering")
+        if key not in self._cache:
+            # Check if engines exist (they are removed during pickling/copying)
+            if not hasattr(self, '_sasmodels'):
+                self._build_sas_engines()
+
+            if self._sasmodels:
+                pars = {k: float(p) for k, p in self.sas_model.parameters.items()}
+                Iq = np.hstack([sasmodel(**pars) for sasmodel in self._sasmodels])
+            else:
+                # Fallback if no models defined
+                # Determine total length of Q
+                if hasattr(self.probe, 'probes'):
+                     n = sum(len(p.Q) for p in self.probe.probes)
+                else:
+                     n = len(self.probe.Q)
+                Iq = np.zeros(n)
+
             self._cache[key] = Iq
         return self._cache[key]
 
@@ -125,10 +157,7 @@ class SASReflectivityExperiment(SASReflectivityMixin, Experiment):
     sas_model: 'SASReflectivityModel' = None
 
     def __init__(self, sas_model=None, sample=None, probe=None, name=None, **kwargs):
-        # 1. Initialize Parent (Experiment)
         super().__init__(sample, probe, name, **kwargs)
-        
-        # 2. Initialize Mixin
         self._init_sas(sas_model)
 
 
@@ -141,11 +170,7 @@ class SASReflectivityMolgroupsExperiment(SASReflectivityMixin, MolgroupsExperime
     sas_model: 'SASReflectivityModel' = None
 
     def __init__(self, sas_model=None, sample=None, probe=None, name=None, **kwargs):
-        # 1. Initialize Parent (MolgroupsExperiment)
-        # This automatically registers the CVO plots, Table plots, etc.
         super().__init__(sample, probe, name, **kwargs)
-        
-        # 2. Initialize Mixin
         self._init_sas(sas_model)
     
 def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> CustomWebviewPlot:
@@ -162,7 +187,6 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
         return np.ravel(np.array(arr, dtype=float))
 
     # 2. Get Concatenated Theory Components
-    # model.reflectivity() and sas() return 1D arrays matching the full concatenated Q
     Q_all_raw, total_theory_raw = model.reflectivity()
     Q_all = to_flat(Q_all_raw)
     total_theory = to_flat(total_theory_raw)
@@ -183,51 +207,37 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
     # 4. Construct Plotly Figure
     fig = go.Figure()
     
-    # Cursor to track where we are in the concatenated arrays
     cursor = 0
     
-    # Loop over probes to slice data and plot traces
     for i, probe in enumerate(probes):
-        # Determine slice range for this probe
+        # Determine slice range
         n_points = len(probe.Q)
         start = cursor
         end = cursor + n_points
         
-        # Slice the arrays
+        # Slice arrays
         Q = Q_all[start:end]
         Total = total_theory[start:end]
         Rq = Rq_all[start:end]
         Iq = Iq_all[start:end]
         
-        # Get Data for this probe
+        # Get Data
         data_y = to_flat(probe.R)
         data_dy = to_flat(probe.dR)
         
-        # Define Color for this Probe (Cycle through COLORS)
         base_color = COLORS[i % len(COLORS)]
         
-        # -- Trace: Data --
+        # Trace: Data
         fig.add_trace(go.Scatter(
             x=Q, y=data_y,
-            error_y=dict(
-                type='data', 
-                array=data_dy, 
-                visible=True,
-                color=base_color,
-                thickness=1
-            ),
+            error_y=dict(type='data', array=data_dy, visible=True, color=base_color, thickness=1),
             mode='markers',
             name=f'Data (Probe {i+1})',
-            marker=dict(
-                color=base_color,
-                symbol='circle',
-                size=6,
-                opacity=0.4
-            ),
+            marker=dict(color=base_color, symbol='circle', size=6, opacity=0.4),
             legendgroup=f'group{i}'
         ))
 
-        # -- Trace: Total Theory (Solid) --
+        # Trace: Total Theory
         fig.add_trace(go.Scatter(
             x=Q, y=Total,
             mode='lines',
@@ -236,8 +246,7 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
             legendgroup=f'group{i}'
         ))
 
-        # -- Trace: Reflectivity (Dash) --
-        # showlegend=True explicitly added
+        # Trace: Reflectivity
         fig.add_trace(go.Scatter(
             x=Q, y=Rq,
             mode='lines',
@@ -247,8 +256,7 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
             showlegend=True 
         ))
 
-        # -- Trace: SANS (Dot) --
-        # showlegend=True explicitly added
+        # Trace: SANS
         fig.add_trace(go.Scatter(
             x=Q, y=Iq,
             mode='lines',
@@ -258,7 +266,6 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
             showlegend=True 
         ))
 
-        # Advance cursor
         cursor += n_points
 
     # 5. Styling
@@ -267,22 +274,16 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
         xaxis_title='Q (Å⁻¹)',
         xaxis_type='linear',
         template='plotly_white',
-        yaxis=dict(
-            title='Intensity (R + I)',
-            type='log',
-            exponentformat='power', 
-            showexponent='all'
-        ),
+        yaxis=dict(title='Intensity (R + I)', type='log', exponentformat='power', showexponent='all'),
         legend=dict(x=0.01, y=0.01, xanchor='left', yanchor='bottom', bgcolor='rgba(255,255,255,0.8)')
     )
 
-    # 6. Prepare CSV Export Data (Concatenated)
+    # 6. Prepare CSV Export Data
     csv_header = "Q,R,dR,Theory,Rq,Iq\n"
     csv_rows = []
     
     n_pts_total = min(len(Q_all), len(total_theory))
     
-    # Re-flatten probe data for CSV export
     if hasattr(model.probe, 'probes'):
         all_data_y = np.hstack([to_flat(p.R) for p in model.probe.probes])
         all_data_dy = np.hstack([to_flat(p.dR) for p in model.probe.probes])
@@ -296,6 +297,4 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
     
     export_data = csv_header + "\n".join(csv_rows)
 
-    return CustomWebviewPlot(fig_type='plotly', 
-                             plotdata=fig, 
-                             exportdata=export_data)
+    return CustomWebviewPlot(fig_type='plotly', plotdata=fig, exportdata=export_data)

--- a/molgroups/refl1d_interface/sas.py
+++ b/molgroups/refl1d_interface/sas.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass, field
 import copy
+import functools
 
 import numpy as np
 import plotly.graph_objs as go
@@ -14,11 +15,14 @@ from refl1d.probe import ProbeSet
 from refl1d.probe.resolution import dTdL2dQ, sigma2FWHM
 from refl1d.webview.server.colors import COLORS
 
-from sasmodels.core import load_model
+from sasmodels.core import load_model, load_model_info, build_model
 from sasmodels.direct_model import DirectModel
 from sasmodels.data import Data1D
+from sasmodels.modelinfo import parse_parameter, ParameterTable
 
 from .experiment import MolgroupsExperiment
+from .layers import MolgroupsLayer
+from .plots import cvo_plot, cvo_uncertainty_plot
 
 # --- 1. THE INTERFACE (Base Class) ---
 
@@ -40,6 +44,25 @@ class SASModel:
         """
         raise NotImplementedError("Subclasses must implement calculate()")
     
+    def get_profile(self):
+        """
+        Return the radial SLD profile as (radius_array, sld_array, labels).
+        labels is a tuple (xlabel, ylabel).
+        Returns (None, None, None) if not available.
+        """
+        return None, None, None
+
+    def get_plots(self):
+        """
+        Return a dictionary of plots to register with the webview.
+        Structure:
+        {
+            'parameter': [(title, plot_function), ...],
+            'uncertainty': [(title, plot_function), ...]
+        }
+        """
+        return {'parameter': [], 'uncertainty': []}
+    
     @property
     def parameters(self):
         """
@@ -54,8 +77,6 @@ class SASModel:
 class StandardSASModel(SASModel):
     """
     A SAS model that uses the standard sasmodels library (DirectModel).
-    Manages its own pickling state to handle C-pointers safely.
-    Params should match the parameters expected by the model.
     """
     sas_model_name: str
     params: dict[str, float | Parameter] = field(default_factory=dict)
@@ -66,51 +87,68 @@ class StandardSASModel(SASModel):
     _probe: object = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
-        # Ensure all inputs in params are converted to Bumps Parameters.
-        # This runs immediately on instantiation, so 'params' always holds objects.
         for k, v in self.params.items():
             if not isinstance(v, Parameter):
                 self.params[k] = Parameter.default(v, name=k)
 
     def bind(self, probe):
-        """
-        Store the probe and initialize the DirectModel engines.
-        """
         self._probe = probe
-        # Clear existing engines so they are rebuilt for the new probe
         self._engines = None 
-        # Build immediately for speed
         self._build_engines()
 
+    def _generate_params(self):
+        return {k: v.value for k, v in self.params.items()}
+
     def calculate(self):
-        """
-        Lazy-load engines if missing (e.g. after unpickling), then calculate.
+        if self._engines is None:
+            self._build_engines()
+            
+        if not self._engines:
+            return np.array([])
+            
+        pars = self._generate_params()
+        parts = [model(**pars) for model in self._engines]
+        return np.hstack(parts)
+
+    def get_profile(self):
+        """ Retrieve profile from the engine if supported """
+        if self._engines is None:
+            self._build_engines()
+        
+        # Guard against empty engine list or missing profile method
+        if not self._engines or not hasattr(self._engines[0], 'profile'):
+            return None, None, None
+
+        pars = self._generate_params()
+        try:
+            # sasmodels profile returns x, y, (xlabel, ylabel)
+            return self._engines[0].profile(**pars)
+        except (AttributeError, TypeError, NotImplementedError):
+            return None, None, None
+
+    def get_plots(self):
+        """ 
+        Return list of Standard SAS plots categorized by update trigger.
         """
         if self._engines is None:
             self._build_engines()
             
-        # Run calculation across all engines
-        if not self._engines:
-            return np.array([])
-            
-        pars = {k: v.value for k, v in self.params.items()}
-        parts = [model(**pars) for model in self._engines]
-        return np.hstack(parts)
+        plots = {'parameter': [], 'uncertainty': []}
+        
+        if self._engines and hasattr(self._engines[0], 'profile'):
+             plots['parameter'].append(('SANS Profile', sans_profile_plot))
+             
+        return plots
 
     def _build_engines(self):
-        """
-        The compilation logic. Rebuilds _engines using the bound probe and kernel.
-        """
         if not self.sas_model_name or self._probe is None:
             self._engines = []
             return
 
         kernel = load_model(self.sas_model_name)
         
-        # Handle ProbeSet vs Single Probe
         probes = [self._probe] if not isinstance(self._probe, ProbeSet) else self._probe.probes
 
-        # Handle dtheta_l broadcasting
         if np.isscalar(self.dtheta_l) or self.dtheta_l is None:
             dtheta_list = [self.dtheta_l] * len(probes)
         else:
@@ -119,34 +157,253 @@ class StandardSASModel(SASModel):
         new_engines = []
         for probe, dt in zip(probes, dtheta_list):
             data = Data1D(x=probe.Q)
-            # Resolution calculation
             data.dxl = dTdL2dQ(np.zeros_like(probe.T), dt, probe.L, probe.dL)
             data.dxw = 2 * sigma2FWHM(probe.dQ) if hasattr(probe, 'dQ') else np.zeros_like(probe.Q)
-            
             new_engines.append(DirectModel(data=data, model=kernel))
             
         self._engines = new_engines
 
     def __getstate__(self):
-        """
-        Custom pickling: Drop the C-pointer objects (_engines).
-        IMPORTANT: 'params' IS preserved here, allowing Bumps to handle 
-        parameter state persistence during serialization.
-        """
         state = self.__dict__.copy()
         state['_engines'] = None 
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        # _engines is None; will be rebuilt by calculate()
 
     @property
     def parameters(self):
         return self.params
 
 
-# --- 3. THE MIXIN ---
+# --- 3. MOLGROUPS IMPLEMENTATION ---
+
+@dataclass
+class MolgroupsSphereSASModel(SASModel):
+    """
+    Maps a MolgroupsLayer profile to the sasmodels 'core_multi_shell' kernel.
+    Assumes spherical symmetry for volume scaling.
+    """
+    molgroups_layer: MolgroupsLayer
+    dz: float = 5.0
+    
+    # Common parameters
+    r_core: Parameter | float = 0.0
+    scale: Parameter | float = 1.0
+    background: Parameter | float = 0.0
+
+    # Fixed configuration
+    sas_model_name: str = 'core_multi_shell'
+    geometry_exponent: int = 2 # Sphere (p=2)
+
+    # Internal state
+    _engines: list[DirectModel] | None = field(default=None, init=False, repr=False)
+    _probe: object = field(default=None, init=False, repr=False)
+    _last_n_shells: int = field(default=0, init=False, repr=False)
+    _kernel: object = field(default=None, init=False, repr=False)
+    
+    def __post_init__(self):
+        for name in ['r_core', 'scale', 'background']:
+            val = getattr(self, name)
+            if not isinstance(val, Parameter):
+                setattr(self, name, Parameter.default(val, name=name))
+
+    @property
+    def parameters(self):
+        mg_params = self.molgroups_layer.parameters()
+        own_params = {
+            'r_core': self.r_core,
+            'scale': self.scale, 
+            'background': self.background
+        }
+        return mg_params | own_params
+
+    def bind(self, probe):
+        self._probe = probe
+        self._engines = None
+        self._kernel = None
+        self._last_n_shells = 0
+
+    def get_profile(self):
+        """ 
+        Reconstruct the radial SLD profile using the engine's profile method. 
+        """
+        # 1. Discretize Layer
+        thickness = self.molgroups_layer.thickness.value
+        if thickness <= 0: return None, None, None
+
+        z = np.arange(0, thickness, self.dz)
+        sld_layer = self.molgroups_layer._filled_profile(z)
+        n_shells = len(z)
+        if n_shells == 0: return None, None, None
+
+        # 2. Ensure Kernel is built
+        self._ensure_kernel(n_shells)
+        
+        # 3. Generate parameters
+        pars = self._generate_params(z, sld_layer, n_shells)
+        
+        # 4. Retrieve Profile from Engine
+        if not self._engines:
+             self._build_engines_from_kernel()
+             
+        if not self._engines or not hasattr(self._engines[0], 'profile'):
+            return None, None, None
+            
+        try:
+            return self._engines[0].profile(**pars)
+        except (AttributeError, TypeError, NotImplementedError):
+            return None, None, None
+
+    def get_plots(self):
+        """ Return dictionary of categorized plots """
+        plots = {
+            'parameter': [
+                ('SANS Layer Profile', functools.partial(cvo_plot, self.molgroups_layer))
+            ],
+            'uncertainty': [
+                ('SANS Layer CVO', functools.partial(cvo_uncertainty_plot, self.molgroups_layer))
+            ]
+        }
+        
+        # Initialize kernel with safe limit (10) to check for 'profile' capability
+        if self._engines is None and self._probe is not None:
+             self._ensure_kernel(10)
+             
+        if self._engines and hasattr(self._engines[0], 'profile'):
+            # Insert at the beginning of the parameter list
+            plots['parameter'].insert(0, ('SANS Radial Profile', sans_profile_plot))
+
+        return plots
+
+    def _ensure_kernel(self, n_shells):
+        """
+        Dynamically patches the core_multi_shell definition to allow 'n' 
+        to reach the current shell count.
+        """
+        if self._kernel is not None and self._last_n_shells >= n_shells:
+            return
+
+        base_info = load_model_info(self.sas_model_name)
+        my_info = copy.deepcopy(base_info)
+        
+        desired_limit = max(20, n_shells + 10)
+
+        # DEFINE RAW PARAMETERS
+        raw_params = [
+            ["sld_core", "1e-6/Ang^2", 1.0, [-np.inf, np.inf], "sld", "Core scattering length density"],
+            ["radius", "Ang", 200., [0, np.inf], "volume", "Radius of the core"],
+            ["sld_solvent", "1e-6/Ang^2", 6.4, [-np.inf, np.inf], "sld", "Solvent scattering length density"],
+            ["n", "", float(1), [0, n_shells], "volume", "number of shells"],
+            ["sld[n]", "1e-6/Ang^2", 1.7, [-np.inf, np.inf], "sld", "scattering length density of shell k"],
+            ["thickness[n]", "Ang", 40., [0, np.inf], "volume", "Thickness of shell k"],
+        ]
+
+        # PARSE PARAMETERS
+        processed_list = []
+        for entry in raw_params:
+            p = parse_parameter(*entry)
+            p.length_control = None  # Disable sasmodels' internal length checks
+            
+            if '[n]' in p.name:
+                p.length = n_shells
+            else:
+                p.length = 1
+            
+            processed_list.append(p)
+
+        # CREATE TABLE
+        partable = ParameterTable(processed_list)
+        
+        # BUILD MODEL
+        my_info.parameters = partable
+        self._kernel = build_model(my_info)
+        self._last_n_shells = n_shells 
+        
+        # REBUILD ENGINES
+        self._build_engines_from_kernel()
+
+    def _build_engines_from_kernel(self):
+        if self._probe is None: return
+        
+        probes = [self._probe] if not isinstance(self._probe, ProbeSet) else self._probe.probes
+        dtheta_list = [0.0] * len(probes)
+
+        new_engines = []
+        for probe, dt in zip(probes, dtheta_list):
+            data = Data1D(x=probe.Q)
+            data.dxl = dTdL2dQ(np.zeros_like(probe.T), dt, probe.L, probe.dL)
+            data.dxw = 2 * sigma2FWHM(probe.dQ) if hasattr(probe, 'dQ') else np.zeros_like(probe.Q)
+            new_engines.append(DirectModel(data=data, model=self._kernel))
+        
+        self._engines = new_engines
+
+    def calculate(self):
+        thickness = self.molgroups_layer.thickness.value
+        if thickness <= 0: return np.array([])
+        
+        z = np.arange(0, thickness, self.dz)
+        sld = self.molgroups_layer._filled_profile(z)
+        n_shells = len(z)
+        
+        if n_shells == 0: return np.array([])
+
+        self._ensure_kernel(n_shells)
+        
+        pars = self._generate_params(z, sld, n_shells)
+        
+        if not self._engines: return np.array([])
+        parts = [model(**pars) for model in self._engines]
+        return np.hstack(parts)
+
+    def _generate_params(self, z, sld, n_shells):
+        pars = {
+            'scale': self.scale.value,
+            'background': self.background.value,
+            'n': float(n_shells),
+        }
+        
+        r_core_val = self.r_core.value
+        overlap_obj = self.molgroups_layer.base_group.overlap
+        overlap_val = overlap_obj.value if isinstance(overlap_obj, Parameter) else float(overlap_obj)
+
+        if r_core_val > overlap_val:
+            pars['radius'] = r_core_val - overlap_val
+        else:
+            pars['radius'] = 0.0
+
+        pars['sld_core'] = sld[0]
+        pars['sld_solvent'] = self.molgroups_layer.contrast.rho.value
+
+        p = self.geometry_exponent 
+
+        r_start = pars['radius']
+        effective_r_core = max(r_start, overlap_val)
+        
+        for i in range(n_shells):
+            r_current = r_start + z[i]
+            
+            if effective_r_core > 1e-9 and r_current > 1e-9:
+                thick_i = self.dz * (effective_r_core / r_current)**p
+            else:
+                thick_i = self.dz
+            
+            pars[f'thickness{i+1}'] = thick_i
+            pars[f'sld{i+1}'] = sld[i]
+
+        return pars
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['_engines'] = None 
+        state['_kernel'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
+
+# --- 4. THE MIXIN ---
 
 class SASReflectivityMixin:
     """
@@ -163,80 +420,81 @@ class SASReflectivityMixin:
         self.sas_model = sas_model
         
         if self.sas_model is not None:
-            # BINDING: Pass the experiment's probe to the model
             self.sas_model.bind(self.probe)
         
-        # Register plots
+        # Register main SAS/Refl plot
         self.register_webview_plot(
             plot_title='SAS/Refl Decomposition',
             plot_function=sas_decomposition_plot,
             change_with='parameter'
         )
+        
+        # Register model-specific plots via Polymorphism
+        if self.sas_model is not None:
+            plot_groups = self.sas_model.get_plots()
+            
+            # Register parameter-driven plots
+            for title, func in plot_groups.get('parameter', []):
+                self.register_webview_plot(
+                    plot_title=title, 
+                    plot_function=func, 
+                    change_with='parameter'
+                )
+                
+            # Register uncertainty-driven plots
+            for title, func in plot_groups.get('uncertainty', []):
+                self.register_webview_plot(
+                    plot_title=title, 
+                    plot_function=func, 
+                    change_with='uncertainty'
+                )
 
     def parameters(self):
-        # Merge experiment params with the model's params
         base = super().parameters()
         if self.sas_model:
             return base | {'sas': self.sas_model.parameters}
         return base
 
     def sas(self):
-        """ Calculate the small angle scattering I(q) """
         key = ("small_angle_scattering")
         if key not in self._cache:
              if self.sas_model:
                  self._cache[key] = self.sas_model.calculate()
              else:
-                 # Fallback for plotting if no model exists
                  if isinstance(self.probe, ProbeSet):
                      n = sum(len(p.Q) for p in self.probe.probes)
                  else:
                      n = len(self.probe.Q)
                  self._cache[key] = np.zeros(n)
-                 
         return self._cache[key]
 
     def reflectivity(self, resolution=True, interpolation=0):
         Q, Rq = super().reflectivity(resolution, interpolation)
         if self.sas_model is not None:
-            # Add SAS signal (create new array, do not modify in-place)
             Rq = Rq + self.sas()
         return Q, Rq
 
 
-# --- 4. CONCRETE EXPERIMENT CLASSES ---
+# --- 5. CONCRETE EXPERIMENT CLASSES ---
 
 @dataclass(init=False)
 class SASReflectivityExperiment(SASReflectivityMixin, Experiment):
-    """
-    Standard SAS + Reflectivity Experiment.
-    """
     sas_model: SASModel | None = None
-
     def __init__(self, sas_model: SASModel | None = None, sample=None, probe=None, name=None, **kwargs):
         super().__init__(sample, probe, name, **kwargs)
         self._init_sas(sas_model)
 
 @dataclass(init=False)
 class SASReflectivityMolgroupsExperiment(SASReflectivityMixin, MolgroupsExperiment):
-    """
-    Molgroups-Enabled SAS + Reflectivity Experiment.
-    """
     sas_model: SASModel | None = None
-
     def __init__(self, sas_model: SASModel | None = None, sample=None, probe=None, name=None, **kwargs):
         super().__init__(sample, probe, name, **kwargs)
         self._init_sas(sas_model)
 
 
-# --- 5. PLOTTING FUNCTION ---
+# --- 6. PLOTTING FUNCTIONS ---
 
 def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> CustomWebviewPlot:
-    """
-    Webview plot that shows the decomposition of the signal into 
-    Reflectivity (Rq) and SAS (Iq) components.
-    """
-
     def to_flat(arr):
         if arr is None: return np.array([])
         return np.ravel(np.array(arr, dtype=float))
@@ -296,5 +554,39 @@ def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> Cu
     for i in range(n_pts_total):
         row = f"{Q_all[i]:.6e},{all_data_y[i]:.6e},{all_data_dy[i]:.6e},{total_theory[i]:.6e},{Rq_all[i]:.6e},{Iq_all[i]:.6e}"
         csv_rows.append(row)
+    
+    return CustomWebviewPlot(fig_type='plotly', plotdata=fig, exportdata=csv_header + "\n".join(csv_rows))
+
+def sans_profile_plot(experiment: SASReflectivityExperiment, problem=None) -> CustomWebviewPlot:
+    """
+    Unified plot for SANS SLD Profiles (Radius vs SLD).
+    Works for both StandardSASModel (via engine.profile) and MolgroupsSphereSASModel (via calculation).
+    """
+    model = experiment.sas_model
+    if model is None:
+        return CustomWebviewPlot(fig_type='plotly', plotdata=go.Figure(), exportdata="")
+
+    # Retrieve profile via the polymorphic method
+    # Expects (x, y, labels) or (None, None, None)
+    r, sld, labels = model.get_profile()
+
+    if r is None or sld is None:
+        return CustomWebviewPlot(fig_type='plotly', plotdata=go.Figure(layout=dict(title="Profile not available")), exportdata="")
+
+    xlabel, ylabel = 'Radius (Å)', 'SLD (10⁻⁶ Å⁻²)'
+
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=r, y=sld, mode='lines', name='SLD Profile', line=dict(color=COLORS[0], width=3)))
+
+    title_text = getattr(model, 'sas_model_name', 'SAS Model')
+    fig.update_layout(
+        title=f'SANS Radial Profile: {title_text}',
+        xaxis_title=xlabel,
+        yaxis_title=ylabel,
+        template='plotly_white'
+    )
+
+    csv_header = f"{xlabel},{ylabel}\n"
+    csv_rows = [f"{ri:.6e},{sldi:.6e}" for ri, sldi in zip(r, sld)]
     
     return CustomWebviewPlot(fig_type='plotly', plotdata=fig, exportdata=csv_header + "\n".join(csv_rows))

--- a/molgroups/refl1d_interface/sas.py
+++ b/molgroups/refl1d_interface/sas.py
@@ -277,6 +277,7 @@ class MolgroupsSphereSASModel(SASModel):
         r_core (Parameter): Radius of the inner core.
         scale (Parameter): Overall intensity scaling factor.
         background (Parameter): Background intensity.
+        dtheta_l (float or list, optional): Angular divergence for resolution smearing.
     """
     molgroups_layer: MolgroupsLayer
     dz: float = 5.0
@@ -285,6 +286,7 @@ class MolgroupsSphereSASModel(SASModel):
     r_core: Union[Parameter, float] = 0.0
     scale: Union[Parameter, float] = 1.0
     background: Union[Parameter, float] = 0.0
+    dtheta_l: Optional[Union[float, List[float]]] = None
 
     # Fixed configuration
     sas_model_name: str = 'core_multi_shell'
@@ -429,7 +431,12 @@ class MolgroupsSphereSASModel(SASModel):
         if self._probe is None: return
         
         probes = [self._probe] if not isinstance(self._probe, ProbeSet) else self._probe.probes
-        dtheta_list = [0.0] * len(probes)
+        
+        # Handle angular divergence (dtheta) logic
+        if np.isscalar(self.dtheta_l) or self.dtheta_l is None:
+            dtheta_list = [self.dtheta_l] * len(probes)
+        else:
+            dtheta_list = self.dtheta_l # type: ignore
 
         new_engines = []
         for probe, dt in zip(probes, dtheta_list):

--- a/molgroups/refl1d_interface/sas.py
+++ b/molgroups/refl1d_interface/sas.py
@@ -356,10 +356,10 @@ class MolgroupsSphereSASModel(SASModel):
         """ Return dictionary of categorized plots """
         plots: PlotDict = {
             'parameter': [
-                ('SANS Layer Profile', functools.partial(cvo_plot, self.molgroups_layer))
+                (f'{self.molgroups_layer.name}', functools.partial(cvo_plot, self.molgroups_layer))
             ],
             'uncertainty': [
-                ('SANS Layer CVO', functools.partial(cvo_uncertainty_plot, self.molgroups_layer))
+                (f'{self.molgroups_layer.name} CVO plot', functools.partial(cvo_uncertainty_plot, self.molgroups_layer))
             ]
         }
         
@@ -634,6 +634,9 @@ class SASReflectivityMolgroupsExperiment(SASReflectivityMixin, MolgroupsExperime
     def __init__(self, sas_model: Optional[SASModel] = None, sample: Any = None, probe: Any = None, name: Optional[str] = None, **kwargs: Any) -> None:
         super().__init__(sample, probe, name, **kwargs)
         self._init_sas(sas_model)
+
+        if isinstance(self.sas_model, MolgroupsSphereSASModel):
+            self._molgroups_layers.update({self.sas_model.molgroups_layer.name: self.sas_model.molgroups_layer})
 
 
 # --- 6. PLOTTING FUNCTIONS ---

--- a/molgroups/refl1d_interface/sas.py
+++ b/molgroups/refl1d_interface/sas.py
@@ -1,0 +1,202 @@
+""" Module for interfacing combined reflectivity and small angle scattering models
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import plotly.graph_objs as go
+
+from bumps.parameter import Parameter
+from bumps.webview.server.custom_plot import CustomWebviewPlot
+from refl1d.experiment import Experiment
+from refl1d.probe.resolution import dTdL2dQ
+from refl1d.webview.server.colors import COLORS
+
+from sasmodels.core import load_model
+from sasmodels.direct_model import DirectModel
+from sasmodels.data import Data1D
+
+@dataclass
+class SASReflectivityModel:
+    """ Class to hold sasmodels model information
+    """
+    sas_model_name: str | None = None
+    dtheta_l: float | None = None
+    parameters: dict[str, float | Parameter] | None = None
+
+@dataclass(init=False)
+class SASReflectivityExperiment(Experiment):
+    """ Class to interface sasmodels with refl1d Experiment class
+    """
+    
+    sas_model: SASReflectivityModel = None
+
+    def __init__(self,
+                 sas_model: SASReflectivityModel=None,
+                 sample = None,
+                 probe=None,
+                 name=None,
+                 roughness_limit=0,
+                 dz=None,
+                 dA=None,
+                 step_interfaces=None,
+                 smoothness=None,
+                 interpolation=0,
+                 constraints=None,
+                 version = None,
+                 auto_tag=False):
+        
+        super().__init__(sample, probe, name, roughness_limit, dz, dA, step_interfaces, smoothness, interpolation, constraints, version, auto_tag)
+        self.sas_model = sas_model
+
+        # convert all non-Parameter sasmodel parameters to bumps.Parameter
+        if sas_model is not None:
+            for k, p in self.sas_model.parameters.items():
+                if not isinstance(p, Parameter):
+                    self.sas_model.parameters[k] = Parameter.default(p, name=k)
+
+        # create sasmodels kernel
+        if sas_model is not None and sas_model.sas_model_name is not None:
+            self._sasmodel = load_model(sas_model.sas_model_name)
+
+        # Register the Decomposition Plot in the Webview
+        # We use functools.partial to pass 'self' (this experiment instance) 
+        # as the first argument to the plot function.
+        self.register_webview_plot(
+            plot_title='SAS/Refl Decomposition',
+            plot_function=sas_decomposition_plot,
+            change_with='parameter'
+        )
+
+    def parameters(self):
+        return super().parameters() | {'sas': self.sas_model.parameters if self.sas_model is not None else {}}
+
+    def sas(self):
+        """ Calculate the small angle scattering from the reflectivity model
+        """
+        key = ("small_angle_scattering")
+        if key not in self._cache:
+            # Initialize data object for sasmodels
+            # TODO: check whether the resolution functions are FWHM, sigma, etc.
+            data = Data1D(x=self.probe.Q)
+            data.dxl=dTdL2dQ(self.probe.T, self.sas_model.dtheta_l, self.probe.L, self.probe.dL)
+            data.dxw=self.probe.dQ
+
+            # calling float converts all bumps Parameters into their current values
+            pars = {k: float(p) for k, p in self.sas_model.parameters.items()}
+
+            # set data in sasmodels object
+            sasmodel = DirectModel(data=data, model=self._sasmodel)
+
+            # execute calculation
+            Iq = sasmodel(**pars)
+            self._cache[key] = Iq
+        return self._cache[key]
+
+    def reflectivity(self, resolution=True, interpolation=0):
+        Q, Rq = super().reflectivity(resolution, interpolation)
+        Iq = self.sas() if self.sas_model is not None else 0.0
+        return Q, Rq + Iq
+    
+def sas_decomposition_plot(model: SASReflectivityExperiment, problem=None) -> CustomWebviewPlot:
+    """
+    Webview plot that shows the decomposition of the signal into 
+    Reflectivity (Rq) and SAS (Iq) components.
+    
+    Args:
+        model: The SASReflectivityExperiment instance (passed by webview)
+        problem: The Bumps FitProblem (passed by webview)
+    """
+
+    # 2. Calculate Components
+    # Total Theory = R(q) + I(q)
+    # We call reflectivity() which returns the sum
+    Q, total_theory = model.reflectivity()
+    
+    # SANS Component = I(q)
+    # We call sas() directly. Handle case where sas_model might be None
+    if model.sas_model is not None:
+        Iq = model.sas()
+    else:
+        Iq = np.zeros_like(Q)
+        
+    # Reflectivity Component = R(q)
+    # Derived by subtraction to ensure consistency
+    Rq = total_theory - Iq
+
+    # 3. Get Data for comparison
+    data_y = model.probe.R
+    data_dy = model.probe.dR
+
+    # 4. Construct Plotly Figure
+    fig = go.Figure()
+
+    # -- Trace: Data --
+    fig.add_trace(go.Scatter(
+        x=Q, y=data_y,
+        error_y=dict(
+            type='data', 
+            array=data_dy, 
+            visible=True,
+            color='rgba(0, 0, 0, 0.25)'  # <--- Explicit opacity for error bars
+        ),
+        mode='markers',
+        name='Data',
+        marker=dict(
+            color='rgba(0, 0, 0, 0.25)', # <--- Explicit opacity for markers (0.25 = 25% visible)
+            size=6
+        )
+    ))
+
+    # -- Trace: Total Theory --
+    fig.add_trace(go.Scatter(
+        x=Q, y=total_theory,
+        mode='lines',
+        name='Total Model (R+I)',
+        line=dict(color=COLORS[0], width=3)
+    ))
+
+    # -- Trace: Reflectivity Component --
+    fig.add_trace(go.Scatter(
+        x=Q, y=Rq,
+        mode='lines',
+        name='Reflectivity R(q)',
+        line=dict(color=COLORS[1], width=2, dash='dash')
+    ))
+
+    # -- Trace: SANS Component --
+    fig.add_trace(go.Scatter(
+        x=Q, y=Iq,
+        mode='lines',
+        name='SANS I(q)',
+        line=dict(color=COLORS[2], width=2, dash='dot')
+    ))
+
+    # 5. Styling
+    fig.update_layout(
+        title=f'Signal Decomposition: {model.name}',
+        xaxis_title='Q (Å⁻¹)',
+        xaxis_type='linear',
+        template='plotly_white',
+        yaxis=dict(
+                title='Intensity (R + I)',
+                type='log',
+                exponentformat='power',  # <--- This forces 10^x notation
+                showexponent='all'       # Ensures exponents are shown for all ticks
+            ),
+        legend=dict(x=0.01, y=0.01, xanchor='left', yanchor='bottom', bgcolor='rgba(255,255,255,0.8)')
+    )
+
+    # 6. Prepare CSV Export Data
+    # Simple CSV format: Q, Data, Error, Total, Rq, Iq
+    csv_header = "Q,R,dR,Theory,Rq,Iq\n"
+    csv_rows = []
+    for i in range(len(Q)):
+        row = f"{float(Q[i]):.6e},{float(data_y[i]):.6e},{float(data_dy[i]):.6e},{float(total_theory[i]):.6e},{float(Rq[i]):.6e},{float(Iq[i]):.6e}"
+        csv_rows.append(row)
+    
+    export_data = csv_header + "\n".join(csv_rows)
+
+    return CustomWebviewPlot(fig_type='plotly', 
+                             plotdata=fig, 
+                             exportdata=export_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 examples = ["sasdata", "pandas", "sasmodels"]
 refl1d = ["refl1d"]
+sas = ["sasmodels"]
 
 [project.urls]
 repository = "https://github.com/reflectometry/molgroups"


### PR DESCRIPTION
Sometimes reflectivity data have features that look like they might come from small angle scattering. Usually this means the sample needs to be re-made, but there are cases where this might actually be useful data, and other cases where the sources of the small angle scattering can otherwise not be removed.

This PR is for an Experiment-like object that combines SANS and reflectivity data into a single curve, and exposes the parameters of the `sasmodels` SANS model as Bumps parameters. The model specification includes the SANS model name, a dictionary of parameter values, and a transverse angular resolution `dtheta_l` which is used to smear the SANS data.

A custom decomposition plot into I(q) and R(q) is registered as well.
