### PR TITLE
bumps 1.1 reorganized the source tree

### DIFF
--- a/molgroups/refl1d_interface/functionalprofile.py
+++ b/molgroups/refl1d_interface/functionalprofile.py
@@ -18,8 +18,12 @@ import numpy as np
 from ..mol import nSLDObj
 
 from bumps.dream.state import MCMCDraw
-from bumps.webview.server.custom_plot import CustomWebviewPlot
-from refl1d.webview.server.colors import COLORS
+try:
+    from bumps.plots.custom_plot import CustomWebviewPlot
+    from bumps.plots.colors import COLORS
+except ImportError:  # CRUFT: bumps pre-1.1
+    from bumps.webview.server.custom_plot import CustomWebviewPlot
+    from bumps.webview.server.colors import COLORS
 from refl1d.names import Slab, Stack, SLD, Experiment, FitProblem
 from refl1d.sample.flayer import FunctionalProfile
 

--- a/molgroups/refl1d_interface/plots.py
+++ b/molgroups/refl1d_interface/plots.py
@@ -13,10 +13,15 @@ import plotly.graph_objs as go
 
 from bumps.dream.state import MCMCDraw
 from bumps.dream.stats import credible_interval
-from bumps.webview.server.custom_plot import CustomWebviewPlot
 from bumps.plotutil import form_quantiles
+try:
+    from bumps.plots.custom_plot import CustomWebviewPlot
+    from bumps.plots.colors import COLORS
+except ImportError:  # CRUFT: bumps pre-1.1
+    from bumps.webview.server.custom_plot import CustomWebviewPlot
+    from bumps.webview.server.colors import COLORS
+
 from refl1d.names import FitProblem, Experiment
-from refl1d.webview.server.colors import COLORS
 
 from .layers import MolgroupsLayer
 


### PR DESCRIPTION
Files in bumps/webview/server will moved to other parts of the tree on the next release (1.1).

This change allows molgroups to run with both the old and the new locations for the imports.
